### PR TITLE
Revert parser override

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,5 @@
     "source-map-support": "^0.5.12",
     "tslint": "^5.20.1",
     "tslint-microsoft-contrib": "^6.2.0"
-  },
-  "resolutions": {
-	"esprima": "^4.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,7 +951,12 @@ escodegen@1.8.x:
   optionalDependencies:
     source-map "~0.2.0"
 
-esprima@2.7.x, esprima@^2.7.1, esprima@^4.0.0:
+esprima@2.7.x, esprima@^2.7.1:
+  version "2.7.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
+  integrity sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=
+
+esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==


### PR DESCRIPTION
Revert the override - resolutions aren't recursively applied so anything using this package needs to do the override themselves for it to apply correctly.